### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Frontend Knowledge Structure
             - [Notepad++](http://notepad-plus-plus.org/)/[EditPlus](http://www.editplus.com/)
             - [WebStorm](http://www.jetbrains.com/webstorm/)
         - 调试工具
-            - [Firebug](http://getfirebug.com/)
+            - [Firebug](http://getfirebug.com/)/[Firecookie](https://addons.mozilla.org/en-US/firefox/addon/firecookie/)
             - [YSlow](http://developer.yahoo.com/yslow/)
             - [IEDeveloperToolbar](http://www.microsoft.com/en-us/download/details.aspx?id=18359)/[IETester](http://www.my-debugbar.com/wiki/IETester/HomePage)
             - [Fiddler](http://www.fiddler2.com/fiddler2/)


### PR DESCRIPTION
添加 Firecookie. 在Firebug无法很友好管理和查看cookie的时候，这个还是相当给力的。
作为 Firebug 的一个插件，很好的弥补了他的不足之处。
虽然现在 Firebug 貌似已经集成了这个，但是这个独立的 add-on 当初给我剩下了很多功夫。
