### PR TITLE
添加 expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Frontend Knowledge Structure
             - [Markup Validation Service](http://validator.w3.org/)
         - 单元测试
             - [QUnit](http://qunitjs.com/)/[Jasmine](http://pivotal.github.com/jasmine/)
-            - [Mocha](http://visionmedia.github.com/mocha/)/[Should](https://github.com/visionmedia/should.js/)/[Chai](http://chaijs.com/)
+            - [Mocha](http://visionmedia.github.com/mocha/)/[Should](https://github.com/visionmedia/should.js/)/[Chai](http://chaijs.com/)/[Expect](https://github.com/LearnBoost/expect.js/)
         - 自动化测试
             - WebDriver
     - 前端库/框架


### PR DESCRIPTION
Mocha 套件下建议用 expect 作为断言，兼容性比 chai 好，should 一般在 node 中使用。
