### PR TITLE
删除开发工具（ brackets）的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Frontend Knowledge Structure
     - 开发工具
         - IDE
             - [VIM](http://www.vim.org/)/[Sublime Text2](http://www.sublimetext.com/)
-            - [Backets](http://brackets.io/)
             - [Notepad++](http://notepad-plus-plus.org/)/[EditPlus](http://www.editplus.com/)
             - [WebStorm](http://www.jetbrains.com/webstorm/)
             - [Emacs](http://www.gnu.org/software/emacs/)  [EmacsWiki](http://emacswiki.org)


### PR DESCRIPTION
拼写错误（brackets错误的拼写成了backets），而且与最后一个重复
