### PR TITLE
Remove book named "The Zen of CSS Design".

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -167,7 +167,6 @@ The ★ less and easier, the more suitable for starters
 - [More Eric Meyer on CSS](http://www.amazon.com/More-Eric-Meyer-Voices-Matter/dp/0735714258/)★★★
 - [CSS: The Definitive Guide (3rd Edition)](http://www.amazon.com/CSS-Definitive-Eric-A-Meyer/dp/0596527330/)★★
 - [CSS Mastery: Advanced Web Standards Solutions](http://www.amazon.com/CSS-Mastery-Advanced-Standards-Solutions/dp/1430223979/)★★★
-- [The Zen of CSS Design: Visual Enlightenment for the Web](http://www.amazon.com/The-Zen-CSS-Design-Enlightenment/dp/0321303474/)★★★
 
 ### JavaScript
 - [DOM Scripting: Web Design with JavaScript and the Document Object Model](http://www.amazon.com/DOM-Scripting-Design-JavaScript-Document/dp/1430233893/)★

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ Frontend Knowledge Structure
 - [Eric Meyer 谈 CSS（卷二）](http://www.amazon.cn/Eric-Meyer-谈-CSS-迈耶/dp/B00170M84I/)★★★
 - [CSS权威指南 （第3版）](http://book.douban.com/subject/2308234/)★★
 - [精通CSS](http://book.douban.com/subject/4736167/)★★★
-- [CSS禅意花园](http://book.douban.com/subject/2052176/)★★★
 
 ### JavaScript
 - [JavaScript DOM编程艺术 （第2版）](http://book.douban.com/subject/6038371/)★


### PR DESCRIPTION
The book has been obsolete. (fixed #74)
