### PR TITLE
add polymer to lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Frontend Knowledge Structure
         - [Semantic UI](http://www.semantic-ui.com/)
         - [Juice UI](http://juiceui.com/)
         - [Web Atoms](http://webatomsjs.neurospeech.com/)
+        - [Polymer](http://docs.polymerchina.org/)
     - 前端标准/规范
         - [HTTP1.1](http://www.w3.org/Protocols/rfc2616/rfc2616.html)
         - [ECMAScript3/5](http://www.ecma-international.org/publications/standards/Ecma-262.htm)


### PR DESCRIPTION
polymer是2014 google i/o想要推广的前端技术，配合google的Material design，参考https://www.polymer-project.org/docs/elements/material.html
polymer介绍可参考新闻，http://www.csdn.net/article/2013-05-17/2815334-Polymer
