### PR TITLE
Add HAProxy and Stack.gl

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -187,6 +187,8 @@ Although the project would be maintained in plain text instead, I promise a smal
         - SVG: [D3](http://d3js.org/)/[Raphaël](http://raphaeljs.com/)/[Snap.svg](http://snapsvg.io/)/[DataV](http://datavlab.org/datavjs/)
         - Canvas: [CreateJS](http://www.createjs.com/)/[KineticJS](http://kineticjs.com/)
         - [WebGL](http://zh.wikipedia.org/wiki/WebGL)/[Three.JS](http://threejs.org/)
+        - [Stack.gl](http://stack.gl/)
+
 - Backend Engineer
     - Programming languages
         - C/C++/Java/PHP/Ruby/Python/...

--- a/README.en.md
+++ b/README.en.md
@@ -194,6 +194,7 @@ Although the project would be maintained in plain text instead, I promise a smal
         - [Nginx](http://nginx.org/en/)
         - [Apache](http://httpd.apache.org/)
         - [Lighttpd](http://www.lighttpd.net/)
+        - [HAProxy](http://www.haproxy.org/)
     - Databases
         - SQL
         - [MySQL](http://www.mysql.com/)/[PostgreSQL](http://www.postgresql.org/)/[Oracle](http://www.oracle.com/us/products/database/overview/index.html)/[DB2](http://www-01.ibm.com/software/data/db2)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Frontend Knowledge Structure
         - SVG: [D3](http://d3js.org/)/[Raphaël](http://raphaeljs.com/)/[Snap.svg](http://snapsvg.io/)/[DataV](http://datavlab.org/datavjs/)
         - Canvas: [CreateJS](http://www.createjs.com/)/[KineticJS](http://kineticjs.com/)
         - [WebGL](http://en.wikipedia.org/wiki/WebGL)/[Three.JS](http://threejs.org/)
+        - [Stack.gl](http://stack.gl/)
 
 - 后端工程师
     - 编程语言

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Frontend Knowledge Structure
         - [Nginx](http://nginx.org/en/)
         - [Apache](http://httpd.apache.org/)
         - [Lighttpd](http://www.lighttpd.net/)
+        - [HAProxy](http://www.haproxy.org/)
     - 数据库
         - SQL
         - [MySQL](http://www.mysql.com/)/[PostgreSQL](http://www.postgresql.org/)/[Oracle](http://www.oracle.com/us/products/database/overview/index.html)/[DB2](http://www-01.ibm.com/software/data/db2)


### PR DESCRIPTION
## HAProxy
The Reliable, High Performance TCP/HTTP Load Balancer

## Stack.gl
stackgl is an open software ecosystem for WebGL, built on top of browserify and npm