### PR TITLE
增加nw.js、react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Frontend Knowledge Structure
         - [Polymer](http://docs.polymerchina.org/)
         - [Dhtmlx](http://dhtmlx.com/)
         - [qooxdoo](http://qooxdoo.org/)
-        - [React](http://facebook.github.io/react/)
+        - [Nwjs](https://github.com/nwjs/nw.js)
+        - [React](http://facebook.github.io/react/)/[React-native](https://github.com/facebook/react-native)
         - [Brick](http://mozbrick.github.io/)
         - [vue.js](http://cn.vuejs.org/)
     - 前端标准/规范


### PR DESCRIPTION
用nodejs+chromium开发windows、mac、linux桌面应用
NW.js is an app runtime based on Chromium and node.js. 
You can write native apps in HTML and JavaScript with NW.js. 
It also lets you call Node.js modules directly from the DOM and enables a new way of writing native applications with all Web technologies.